### PR TITLE
fix: change node shebang to be more portable in scripts

### DIFF
--- a/maker.js
+++ b/maker.js
@@ -1,4 +1,4 @@
-#!/bin/node
+#!/usr/bin/env node
 
 // Author: ThatOneCalculator ~ https://t1c.dev/
 

--- a/presence.js
+++ b/presence.js
@@ -1,4 +1,4 @@
-#!/bin/node
+#!/usr/bin/env node
 
 const RPC = require('discord-rpc')
 const chalk = require('chalk')


### PR DESCRIPTION
I was running into an issue where I tried running the `rpcmaker` command after installing it with
`npm i -g rpcmaker` but I received a "bad interpreter" error since I usually install node using
`nvm`, which means it won't be located in `/bin`.

Of course, one could symlink the version in `nvm` into `/bin` which works but we might as well
avoid that altogether by using `/usr/bin/env` so that users with `node` in their path won't
run into this issue again.