### PR TITLE
Increase state and description length

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -424,8 +424,8 @@ document.addEventListener("DOMContentLoaded", () => {
 			activity.smallImageText = 'https://drpcm.t1c.dev/'
 		}
 		if (assets !== {}) { activity.assets = assets }
-		if (options.description !== '') { activity.details = options.description.substring(0, 31) }
-		if (options.state !== '') { activity.state = options.state.substring(0, 31) }
+		if (options.description !== '') { activity.details = options.description.substring(0, 63) }
+		if (options.state !== '') { activity.state = options.state.substring(0, 63) }
 		if (options.buttons.length !== 0) { activity.buttons = options.buttons }
 
 


### PR DESCRIPTION
In `index.html`, the state and description fields could hold up to 64 characters, but in `preload.js`, only the first 32 would be pushed with the rich presence object. I've corrected this here to restore the 64 character length that was available previously.
![image](https://user-images.githubusercontent.com/36447611/131037626-bde5f369-f726-4848-afd8-eed25c7c4fb1.png)
![image](https://user-images.githubusercontent.com/36447611/131037655-e4860e9d-7457-4138-9e55-0640a3b85df1.png)
